### PR TITLE
Updating showdown version

### DIFF
--- a/gulp-showdown.js
+++ b/gulp-showdown.js
@@ -7,7 +7,7 @@ function gulpShowdown(options) {
         extensions: ['table']
     }
 
-    var converter = new Showdown.converter(options || defaultOptions)
+    var converter = new Showdown.Converter(options || defaultOptions)
 
     return through.obj(function (file, encoding, cb) {
         var fileText = file.contents.toString()

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "gulpplugin", "gulp-showdown"
   ],
   "dependencies": {
-    "showdown": "^0.4.0",
+    "showdown": "^1.4.3",
     "gulp-util": "^3.0.4",
     "through2": "^0.6.3"
   },


### PR DESCRIPTION
The version of showdown that gulp-showdown uses is quite old and doesn't support new features that I personally need.
